### PR TITLE
Make library usable on Pythons without GUI libraries

### DIFF
--- a/src/turtlethread/visualise.py
+++ b/src/turtlethread/visualise.py
@@ -1,5 +1,4 @@
 from math import atan2
-from turtle import Turtle, Screen
 
 from pyembroidery import JUMP, STITCH, TRIM, EmbPattern, write
 
@@ -12,7 +11,7 @@ def centered_dot(turtle, diameter):
     turtle.pensize(diameter)
     turtle.goto(turtle.position())
     turtle.pensize(pensize)
-    
+
 
 def centered_cross(turtle, length):
     r = length/2
@@ -65,7 +64,14 @@ def visualise_pattern(pattern, turtle=None, width=800, height=800, scale=1, done
         If True, then ``turtle.bye()`` will be called after drawing.
     """
     if USE_SPHINX_GALLERY:
-        return 
+        return
+
+    # Lazy import of 'turtle' module just for visualization so that the rest of
+    # the library can be used on Python installs where the GUI libraries are not
+    # available.
+    #
+    # (This looks like it would conflict with the 'turtle' variable but it does not)
+    from turtle import Turtle, Screen
 
     if turtle is None:
         # If turtle is None, grab the default turtle and set its speed to fastest
@@ -78,9 +84,9 @@ def visualise_pattern(pattern, turtle=None, width=800, height=800, scale=1, done
     screen.setup(width, height)
 
     turtle.penup()
-    turtle.goto(pattern.stitches[0][0], pattern.stitches[0][1])        
+    turtle.goto(pattern.stitches[0][0], pattern.stitches[0][1])
     turtle.pendown()
-    
+
     raise_error = False
     for x, y, command in pattern.stitches:
         x = scale*x
@@ -122,7 +128,7 @@ def visualise_pattern(pattern, turtle=None, width=800, height=800, scale=1, done
     if bye:
         import turtle  # Import turtle only here to avoid cluttering module namespace
         turtle.bye()
-    
+
     if raise_error:
         ValueError(f"Command not supported: {command}")
 


### PR DESCRIPTION
Some Python distributions (notably, the one used on Heroku) are not
built to include the GUI libraries (`tkinter`). We'd like to use
Turtlethread in a web server (https://hedycode.com) but are running
into issues because of this.

Even though `turtlethread` doesn't really need the GUI libraries to do
its main job, just the presence of the `visualize.py` library and it
containing a `from turtle import ...` statement, and the built-in
`turtle` library depending on `tkinter`, makes importing `turtlethread`
fail:

```
>>> import turtlethread
...
ModuleNotFoundError: No module named '_tkinter'
```

This PR moves the import of the built-in turtle module *into* the
`visualize_pattern()` function, so that we'll only fail if the
function is actually called; not when the module is imported.